### PR TITLE
Fix/ss docker volumes option

### DIFF
--- a/src/shallow-snake/docker-compose.yml
+++ b/src/shallow-snake/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       target: development
     image: twinkling-gecko/aodaishou:development
     volumes:
-      - ./src/aodaishou:/usr/src/app:cached
+      - ./src/aodaishou:/usr/src/app
     ports:
       - 3000:3000
 


### PR DESCRIPTION
docker-composeのvolumesからcachedオプションを削除した。

元々macでの開発時のためにハイパーバイザとのストレージ転送の遅さを補うためのオプションだったが、モジュール追加時やHMRがかかったときに整合が取れなくなり挙動がおかしくなることがあったために削除。また、macで直に開発も行わずVMを建てることにしたので不要となった。