### PR TITLE
Feat/ss fix login logic

### DIFF
--- a/src/shallow-snake/src/aodaishou/api/middleware/isAuthenticated.ts
+++ b/src/shallow-snake/src/aodaishou/api/middleware/isAuthenticated.ts
@@ -4,6 +4,6 @@ export default (req: Request, res: Response, next: NextFunction) => {
   if (req.isAuthenticated()) {
     next()
   } else {
-    res.status(204).send()
+    res.status(403).send()
   }
 }

--- a/src/shallow-snake/src/aodaishou/api/passport.ts
+++ b/src/shallow-snake/src/aodaishou/api/passport.ts
@@ -16,12 +16,12 @@ passport.use(
         })
       }
 
-      const password_compared = await comparePlainWithHash(
+      const isCompared = await comparePlainWithHash(
         password,
         user?.encrypted_password || ''
       )
 
-      if (user && password_compared) {
+      if (user && isCompared) {
         return done(null, { id: user?.id, email: user?.email })
       } else {
         // emailに合致するuserが存在しないかpasswordが合致しない場合

--- a/src/shallow-snake/src/aodaishou/api/passport.ts
+++ b/src/shallow-snake/src/aodaishou/api/passport.ts
@@ -16,10 +16,12 @@ passport.use(
         })
       }
 
-      if (
-        user &&
-        comparePlainWithHash(password, user?.encrypted_password || '')
-      ) {
+      const password_compared = await comparePlainWithHash(
+        password,
+        user?.encrypted_password || ''
+      )
+
+      if (user && password_compared) {
         return done(null, { id: user?.id, email: user?.email })
       } else {
         // emailに合致するuserが存在しないかpasswordが合致しない場合
@@ -36,7 +38,6 @@ passport.serializeUser(function (user: User, done) {
 passport.deserializeUser(async function (id: number, done) {
   try {
     const user: User | undefined = await User.findOne({ id: id })
-    console.log(user)
     done(null, user)
   } catch (err) {
     done(err, false)
@@ -44,7 +45,5 @@ passport.deserializeUser(async function (id: number, done) {
 })
 
 const comparePlainWithHash = async (plainPassword: string, hash: string) => {
-  return await bcrypt.compare(plainPassword, hash, (_, result) => {
-    return result
-  })
+  return await bcrypt.compare(plainPassword, hash)
 }

--- a/src/shallow-snake/src/aodaishou/api/routes/v1/sessions/index.ts
+++ b/src/shallow-snake/src/aodaishou/api/routes/v1/sessions/index.ts
@@ -20,12 +20,10 @@ const router = Router()
 router.post(
   '/login',
   passport.authenticate('local', {
-    successRedirect: '/',
-    failureRedirect: '/login',
     session: true,
   }),
   (_, res) => {
-    res.json({ message: 'success' })
+    res.status(200).json({ message: 'message' })
   }
 )
 

--- a/src/shallow-snake/src/aodaishou/api/routes/v1/sessions/index.ts
+++ b/src/shallow-snake/src/aodaishou/api/routes/v1/sessions/index.ts
@@ -23,7 +23,7 @@ router.post(
     session: true,
   }),
   (_, res) => {
-    res.status(200).json({ message: 'message' })
+    res.status(200).json({ message: 'success' })
   }
 )
 

--- a/src/shallow-snake/src/aodaishou/pages/login.vue
+++ b/src/shallow-snake/src/aodaishou/pages/login.vue
@@ -29,9 +29,8 @@ export default Vue.extend({
         .then(() => {
           this.$router.push('/')
         })
-        .catch((error) => {
-          console.log(error)
-        })
+        // FIXME: 失敗したことをユーザーに通知
+        .catch(err => {})
     },
   },
 })


### PR DESCRIPTION
passportが認証成功のステータスにかかわらず、レスポンスにHTMLが渡されていた
ステータスコードとともにjsonを返すように変更