### PR TITLE
[SS] feat: add docker presistent volumes

### DIFF
--- a/src/shallow-snake/docker-compose.yml
+++ b/src/shallow-snake/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     image: twinkling-gecko/aodaishou:development
     volumes:
       - ./src/aodaishou:/usr/src/app
+      - aodaishou_node_modules:/usr/src/app/node_modules
     ports:
       - 3000:3000
     depends_on:
@@ -16,7 +17,7 @@ services:
   nishiki:
     image: mysql:latest
     volumes:
-      - ./.db:/var/lib/mysql:cached
+      - nishiki_db_volume:/var/lib/mysql
     environment:
       - MYSQL_ROOT_PASSWORD=mamushi
       - MYSQL_DATABASE=sparkling
@@ -24,3 +25,7 @@ services:
       - MYSQL_PASSWORD=mamushi
     ports:
       - 3306:3306
+
+volumes:
+  aodaishou_node_modules:
+  nishiki_db_volume:


### PR DESCRIPTION
aodaishouのnode_modules、nishikiのDBファイルをvolumesへ変更することでDocker for Macでのvolume mountによるパフォーマンス低下に対策した。

ホスト側ディレクトリへこれらのファイルが生成されなくなるため、node_modules以下を見てコーディング支援を働かせる環境ではそれ用に**ホスト側で**`yarn install`が必要となる。VSCodeの場合はRemote Developmentで直にコンテナに繋ぐほうが快適そう（要検証）。

FYI: https://docs.docker.com/storage/volumes/